### PR TITLE
Fix controller generation errors

### DIFF
--- a/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
+++ b/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
@@ -335,6 +335,7 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
                     pr++;
                 }
 
+                pr = 0;
                 foreach (string param in parseLayers)
                 {
 
@@ -365,6 +366,8 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
                     BlendTree childMotion = CreateCombinedTree(decodeLayer.FloatParameter(param), minusClip, zeroClip, oneClip);
 
                     binarySumTopLevelChildMotions[pr] = new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f};
+
+                    pr++;
                 }
 
                 binarySumTopLevelDirectBlendTree.children = binarySumTopLevelChildMotions;

--- a/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
+++ b/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
@@ -336,7 +336,7 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
                 }
 
 //                pr = 0;
-                foreach (string param in parseLayers)
+                foreach (string param in selectedFloatParams)
                 {
 
                     var zeroClip  = aac.NewClip(param+"_0_scaled");

--- a/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
+++ b/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
@@ -229,7 +229,8 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
                 decodeLayer.OverrideValue(binarySumTopLevelNormalizerParam, 1f/(float)summingLayerCount);
 
                 var binarySumTopLevelDirectBlendTree = aac.NewBlendTreeAsRaw();
-                ChildMotion[] binarySumTopLevelChildMotions = new ChildMotion[summingLayerCount];
+                List<ChildMotion> binarySumTopLevelChildMotions = new List<ChildMotion>();
+//                ChildMotion[] binarySumTopLevelChildMotions = new ChildMotion[summingLayerCount];
 
                 binarySumTopLevelDirectBlendTree.blendType = BlendTreeType.Direct;
                 binarySumTopLevelDirectBlendTree.blendParameter = binarySumTopLevelNormalizerParam.Name;
@@ -330,12 +331,13 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
                         childMotion = parameterDirectBlendTreePositive;
                     }
 
-                    binarySumTopLevelChildMotions[pr] = new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f};
+                    binarySumTopLevelChildMotions.Add(new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f});
+                    //binarySumTopLevelChildMotions[pr] = new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f};
 
                     pr++;
                 }
 
-                pr = 0;
+//                pr = 0;
                 foreach (string param in parseLayers)
                 {
 
@@ -365,12 +367,13 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
 
                     BlendTree childMotion = CreateCombinedTree(decodeLayer.FloatParameter(param), minusClip, zeroClip, oneClip);
 
-                    binarySumTopLevelChildMotions[pr] = new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f};
+//                    binarySumTopLevelChildMotions[pr] = new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f};
+                    binarySumTopLevelChildMotions.Add(new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f});
 
                     pr++;
                 }
 
-                binarySumTopLevelDirectBlendTree.children = binarySumTopLevelChildMotions;
+                binarySumTopLevelDirectBlendTree.children = binarySumTopLevelChildMotions.ToArray();
                 binarySumState.WithAnimation(binarySumTopLevelDirectBlendTree);
             }
 

--- a/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
+++ b/Assets/Razgriz/VRCFTGenerator/VRCFTGenerator.cs
@@ -230,7 +230,6 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
 
                 var binarySumTopLevelDirectBlendTree = aac.NewBlendTreeAsRaw();
                 List<ChildMotion> binarySumTopLevelChildMotions = new List<ChildMotion>();
-//                ChildMotion[] binarySumTopLevelChildMotions = new ChildMotion[summingLayerCount];
 
                 binarySumTopLevelDirectBlendTree.blendType = BlendTreeType.Direct;
                 binarySumTopLevelDirectBlendTree.blendParameter = binarySumTopLevelNormalizerParam.Name;
@@ -332,7 +331,6 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
                     }
 
                     binarySumTopLevelChildMotions.Add(new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f});
-                    //binarySumTopLevelChildMotions[pr] = new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f};
 
                     pr++;
                 }
@@ -367,7 +365,6 @@ namespace AnimatorAsCodeFramework.Razgriz.VRCFTGenerator
 
                     BlendTree childMotion = CreateCombinedTree(decodeLayer.FloatParameter(param), minusClip, zeroClip, oneClip);
 
-//                    binarySumTopLevelChildMotions[pr] = new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f};
                     binarySumTopLevelChildMotions.Add(new ChildMotion {motion = childMotion, directBlendParameter = binarySumTopLevelNormalizerParam.Name, timeScale = 1.0f, threshold = 0.0f});
 
                     pr++;


### PR DESCRIPTION
This fixes:
1. pr not being incremented in the second foreach loop making subsequent loops act on only the first element of the array
2. an index-out-of-range error in the binarySum array when pr is incremented in the second foreach loop by switching the ChildMotion array for a List; this also fixes errors stemming from uninitialized values in the array