### PR TITLE
Simplify generated controllers for WD ON

### DIFF
--- a/VRCFTGenerator.cs
+++ b/VRCFTGenerator.cs
@@ -507,7 +507,8 @@ namespace Raz.VRCFTGenerator
                 var decodeLayer = aac.CreateSupportingFxLayer("BinaryCombinedDecode");
                 var binarySumState = decodeLayer.NewState("DecodeBlendTree");
                 var binarySumTopLevelNormalizerParam = decodeLayer.FloatParameter(SystemPrefix + "DecodeBlendTreeNormalizer");
-                decodeLayer.OverrideValue(binarySumTopLevelNormalizerParam, 1f/(float)decodeBlendtreeChildren);
+                float binarySumTopLevelNormalizerValue = my.writeDefaults ? 1f : 1f/(float)decodeBlendtreeChildren;
+                decodeLayer.OverrideValue(binarySumTopLevelNormalizerParam, binarySumTopLevelNormalizerValue);
 
                 var parameterDirectTreeNormalizer = decodeLayer.FloatParameter(SystemPrefix + "Constant_1");
                 fx.OverrideValue(parameterDirectTreeNormalizer, 1f);
@@ -531,7 +532,7 @@ namespace Raz.VRCFTGenerator
                     {
                         var paramToAnimate = decodeLayer.FloatParameter(SystemPrefix + keyframeParam);
 
-                        float oneClipVal = keyframeParam == param ? 1f*(float)decodeBlendtreeChildren : 0f;
+                        float oneClipVal = keyframeParam == param ? (my.writeDefaults ? 1f : 1f*(float)decodeBlendtreeChildren) : 0f;
 
                         bool keyframeParamIsCombined = VRCFTValues.CombinedMapping.ContainsKey(keyframeParam);
                         var keyframePositiveName = keyframeParamIsCombined ? VRCFTValues.CombinedMapping[keyframeParam][0] : keyframeParam;
@@ -640,7 +641,8 @@ namespace Raz.VRCFTGenerator
 
                 // Need to normalize all direct blendtree weights to sum to 1
                 var directNormalizer = fx.FloatParameter(SystemPrefix + "SmoothingDrivingTreeNormalizer");
-                fx.OverrideValue(directNormalizer, 1/(float)numDirectStates);
+                float directNormalizerValue = my.writeDefaults ? 1f : 1f/(float)numDirectStates;
+                fx.OverrideValue(directNormalizer, directNormalizerValue);
 
                 List<ChildMotion> smoothingChildMotions = new List<ChildMotion>();
 
@@ -661,7 +663,7 @@ namespace Raz.VRCFTGenerator
                     {
                         var paramNameSmoothed = fx.FloatParameter(SystemPrefix + paramName + "_Smoothed");
 
-                        float driveVal = paramName == parameterToSmooth ? 1f*(float)numDirectStates : 0f;
+                        float driveVal = paramName == parameterToSmooth ? (my.writeDefaults ? 1 : 1f*(float)numDirectStates) : 0f;
                         zeroClip.Animating(clip => clip.AnimatesAnimator(paramNameSmoothed).WithOneFrame(0f));
                         oneClip.Animating(clip => clip.AnimatesAnimator(paramNameSmoothed).WithOneFrame(driveVal));
                         

--- a/VRCFTGenerator.cs
+++ b/VRCFTGenerator.cs
@@ -533,6 +533,9 @@ namespace Raz.VRCFTGenerator
                     {
                         var paramToAnimate = decodeLayer.FloatParameter(SystemPrefix + keyframeParam);
 
+                        if(my.writeDefaults && keyframeParam != param)
+                            continue;
+
                         float oneClipVal = keyframeParam == param ? (my.writeDefaults ? 1f : 1f*(float)decodeBlendtreeChildren) : 0f;
 
                         bool keyframeParamIsCombined = VRCFTValues.CombinedMapping.ContainsKey(keyframeParam);
@@ -605,6 +608,9 @@ namespace Raz.VRCFTGenerator
                     {
                         var paramToAnimate = decodeLayer.FloatParameter(SystemPrefix + keyframeParam);
 
+                        if(my.writeDefaults && keyframeParam != param)
+                            continue;
+
                         float oneClipVal = keyframeParam == param ? 1f*(float)decodeBlendtreeChildren : 0f;
 
                         bool keyframeParamIsCombined = VRCFTValues.CombinedMapping.ContainsKey(keyframeParam);
@@ -663,6 +669,9 @@ namespace Raz.VRCFTGenerator
                     foreach(string paramName in smoothingParams)
                     {
                         var paramNameSmoothed = fx.FloatParameter(SystemPrefix + paramName + "_Smoothed");
+
+                        if(my.writeDefaults && paramName != parameterToSmooth)
+                            continue;
 
                         float driveVal = paramName == parameterToSmooth ? (my.writeDefaults ? 1 : 1f*(float)numDirectStates) : 0f;
                         zeroClip.Animating(clip => clip.AnimatesAnimator(paramNameSmoothed).WithOneFrame(0f));

--- a/VRCFTGenerator.cs
+++ b/VRCFTGenerator.cs
@@ -24,7 +24,8 @@ namespace Raz.VRCFTGenerator
         public VRCAvatarDescriptor avatar;
         public AnimatorController assetContainer;
         public string assetKey;
-        public bool writeDefaults = false;
+        [Header("This will change how the controller is generated. Recommended to keep on, regardless of rest of controller.")]
+        public bool writeDefaults = true;
         public bool removeAnimatorParams = true;
         public bool manageExpressionParameters = true;
 


### PR DESCRIPTION
Make the following changes with WD ON enabled:
- Don't generate all keyframes in all anims
- Don't normalize
- Use Constant 1 for blending parameters